### PR TITLE
Attempt to fix the microcontroller crashes caused by overclocking

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -12,13 +12,6 @@ pico_sdk_init()
 
 add_executable(pmemtest)
 
-target_compile_definitions(pmemtest PRIVATE
-	PLL_SYS_REFDIV=1
-	PLL_SYS_VCO_FREQ_HZ=1500000000
-	PLL_SYS_POSTDIV1=5
-	PLL_SYS_POSTDIV2=1
-)
-
 pico_generate_pio_header(pmemtest ${CMAKE_CURRENT_LIST_DIR}/ram4164.pio)
 pico_generate_pio_header(pmemtest ${CMAKE_CURRENT_LIST_DIR}/ram4116.pio)
 pico_generate_pio_header(pmemtest ${CMAKE_CURRENT_LIST_DIR}/ram4132.pio)

--- a/firmware/pmemtest.c
+++ b/firmware/pmemtest.c
@@ -11,6 +11,7 @@
 #include "pico/util/queue.h"
 #include "hardware/pio.h"
 #include "hardware/vreg.h"
+#include "hardware/clocks.h"
 #include "pio_patcher.h"
 #include "mem_chip.h"
 #include "xoroshiro64starstar.h"
@@ -798,7 +799,11 @@ int main() {
     int i, retval;
 
     // Increase core voltage slightly (default is 1.1V) to better handle overclock
-    vreg_set_voltage(VREG_VOLTAGE_1_15);
+    vreg_set_voltage(VREG_VOLTAGE_1_20);
+    sleep_ms(50);
+
+    // Overclock to 300 Mhz
+    set_sys_clock_pll(1500000000, 5, 1);
 
     // PLL->prim = 0x51000.
 


### PR DESCRIPTION
This PR addresses the issue of unreliable operation, which is presumably caused by overclocking to 300 MHz.

These are the changes:

- the Pi Pico 2 now boots with the default clock frequency of 150 Mhz
- in `main()` the core voltage is increased to 1.2 V (1.15 V might work as well, I have not tested this)
- after that a short wait was introduced to allow the core voltage to settle
- only afterwards `set_sys_clock_pll()` is called to increase the clock frequency to 300 Mhz

With these changes, we have seen at least three Pi Pico 2s boot 100% of the time, which were previously only booting occasionally.

My theory about what caused the boot problems is as follows:
- some RP2350 need an increased core voltage to operate reliably with the overclock
- by providing the `PLL_SYS_XXX` compile definitions the overclock is applied before `main()` is even called
- only in `main()` the core coltage is increased

This means that the MCU must run for a period of time with insufficient core voltage. Sometimes this works, sometimes it crashes before `vreg_set_voltage()` is called. Thus the unreliable boot behavior.

I looked into this issue as part of a group buy on [Forum64](https://www.forum64.de/). You can see the relevant discussion [here](https://www.forum64.de/index.php?thread/159643-m%C3%B6gliche-sammelbestellung-pico-dram-tester/&pageNo=7) (in german).